### PR TITLE
InputFileButton の data属性を指定できるように変更

### DIFF
--- a/src/components/atoms/InputFileButton/index.tsx
+++ b/src/components/atoms/InputFileButton/index.tsx
@@ -5,7 +5,9 @@ import styles from "./styles.module.css";
 
 type Props = {
   buttonProps: ComponentProps<typeof Button>;
-  inputProps: ComponentProps<"input">;
+  inputProps: ComponentProps<"input"> & {
+    [K in `data-${string}`]: string;
+  };
   className?: string;
 };
 
@@ -13,13 +15,7 @@ export const InputFileButton = forwardRef<HTMLInputElement, Props>(
   function InputFileButtonBase({ buttonProps, inputProps, className }, ref) {
     return (
       <div className={clsx(styles.module, className)}>
-        <input
-          aria-label="画像選択"
-          data-testid="file"
-          {...inputProps}
-          type="file"
-          ref={ref}
-        />
+        <input aria-label="画像選択" {...inputProps} type="file" ref={ref} />
         <Button {...buttonProps} />
       </div>
     );

--- a/src/components/molecules/PostFormHeroImage/index.tsx
+++ b/src/components/molecules/PostFormHeroImage/index.tsx
@@ -55,6 +55,7 @@ export const PostFormHeroImage = (props: Props) => {
           variant: "small",
         }}
         inputProps={{
+          "data-testid": "file",
           accept: "image/png, image/jpeg",
           onChange: onChangeImage,
         }}

--- a/src/components/templates/MyPostsCreate/index.test.tsx
+++ b/src/components/templates/MyPostsCreate/index.test.tsx
@@ -29,7 +29,14 @@ async function setup() {
   async function clickButton(name: "はい" | "いいえ") {
     await user.click(screen.getByRole("button", { name }));
   }
-  return { container, typeTitle, saveAsPublished, saveAsDraft, clickButton, selectImage };
+  return {
+    container,
+    typeTitle,
+    saveAsPublished,
+    saveAsDraft,
+    clickButton,
+    selectImage,
+  };
 }
 
 setupMockServer(...MyPosts.handlers, ...MyProfile.handlers);

--- a/src/components/templates/MyProfileEdit/Avatar/index.tsx
+++ b/src/components/templates/MyProfileEdit/Avatar/index.tsx
@@ -39,6 +39,7 @@ export const Avatar = (props: Props) => {
           type: "button",
         }}
         inputProps={{
+          "data-testid": "file",
           accept: "image/png, image/jpeg",
           onChange: onChangeImage,
         }}

--- a/src/services/client/MyPosts/__mock__/msw.ts
+++ b/src/services/client/MyPosts/__mock__/msw.ts
@@ -7,7 +7,7 @@ import { createMyPostsData } from "./fixture";
 export function handleCreateMyPosts(spy?: jest.Mock<any, any>) {
   return rest.post(path(), async (req, res, ctx) => {
     const data: ApiMyPosts.PostInput = await req.json();
-    spy?.({ body: data, headers: req.headers.get('content-type') })
+    spy?.({ body: data, headers: req.headers.get("content-type") });
     if (data.title === "500") {
       const err = new HttpError(500).serialize();
       return res(ctx.status(err.status), ctx.json(err));


### PR DESCRIPTION
`src/components/atoms/InputFileButton/index.tsx` で inputProps に data属性を指定できるように変更しました。
紙面掲載サンプルへの影響はありません。