### PR TITLE
Storybook Test runner の A11y includedImpacts に "serious" を追加

### DIFF
--- a/.storybook/test-runner.js
+++ b/.storybook/test-runner.js
@@ -19,7 +19,7 @@ module.exports = {
       rules: storyContext.parameters?.a11y?.config?.rules,
     });
     await checkA11y(page, "#root", {
-      includedImpacts: ["critical"],
+      includedImpacts: ["critical", "serious"],
       detailedReport: false,
       detailedReportOptions: { html: true },
       axeOptions: storyContext.parameters?.a11y?.options,

--- a/src/components/layouts/BasicLayout/Header/index.tsx
+++ b/src/components/layouts/BasicLayout/Header/index.tsx
@@ -30,7 +30,7 @@ export const Header = memo(function HeaderBase() {
           <div
             id="drawer"
             ref={menuRef}
-            aria-hidden={!isOpen}
+            tabIndex={isOpen ? 0 : -1}
             className={clsx(styles.menu, isOpen && styles.isOpen)}
           >
             <Nav onCloseMenu={handleCloseMenu} />

--- a/src/components/layouts/BasicLayout/Header/index.tsx
+++ b/src/components/layouts/BasicLayout/Header/index.tsx
@@ -30,7 +30,6 @@ export const Header = memo(function HeaderBase() {
           <div
             id="drawer"
             ref={menuRef}
-            tabIndex={isOpen ? 0 : -1}
             className={clsx(styles.menu, isOpen && styles.isOpen)}
           >
             <Nav onCloseMenu={handleCloseMenu} />

--- a/src/components/layouts/BasicLayout/Header/styles.module.css
+++ b/src/components/layouts/BasicLayout/Header/styles.module.css
@@ -9,10 +9,6 @@
   border-bottom: 1px solid var(--dark-navy);
 }
 
-.menu {
-  display: flex;
-}
-
 .openMenu {
   display: none;
 }
@@ -32,7 +28,6 @@
   }
 
   .menu {
-    display: block;
     width: 200px;
     height: 100%;
     position: fixed;

--- a/src/components/templates/MyPosts/Posts/PostItem/index.stories.tsx
+++ b/src/components/templates/MyPosts/Posts/PostItem/index.stories.tsx
@@ -6,7 +6,12 @@ export default {
   component: PostItem,
   parameters: {
     a11y: {
-      config: { rules: [{ id: "label", enabled: false }] },
+      config: {
+        rules: [
+          { id: "label", enabled: false },
+          { id: "listitem", enabled: false },
+        ],
+      },
     },
   },
 } as ComponentMeta<typeof PostItem>;

--- a/src/components/templates/Posts/PostItem/index.stories.tsx
+++ b/src/components/templates/Posts/PostItem/index.stories.tsx
@@ -6,7 +6,12 @@ export default {
   component: PostItem,
   parameters: {
     a11y: {
-      config: { rules: [{ id: "label", enabled: false }] },
+      config: {
+        rules: [
+          { id: "label", enabled: false },
+          { id: "listitem", enabled: false },
+        ],
+      },
     },
   },
 } as ComponentMeta<typeof PostItem>;


### PR DESCRIPTION
- listitem 単体の Story には a11y.config.rules に `{ id: "listitem", enabled: false }` を追加
- 以下の指摘に準じて a11y violation を修正

https://dequeuniversity.com/rules/axe/4.4/aria-hidden-focus?application=axeAPI

![image](https://user-images.githubusercontent.com/22139818/235343001-c50da31f-5039-49f1-bdfa-de0a0d41f7ed.png)
